### PR TITLE
Update simplifycommerce-method.js

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/simplifycommerce-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/simplifycommerce-method.js
@@ -131,7 +131,7 @@ define([
                         {
                             scKey: this.getConfig()['public_key'],
                             amount: this.totals().base_grand_total * 100,
-                            currency: this.totals().quote_currency_code,
+                            currency: this.totals().base_currency_code,
                             reference: quote.getQuoteId(),
                             operation: 'create.token',
                             selector: '[data-role=' + this.getCode() + '_pay]',


### PR DESCRIPTION
according to magento settings from admin, online payment methods must use the base currency code and amounts for online payment methods